### PR TITLE
update cmd to julia-basic

### DIFF
--- a/config/Julia/Main.sublime-menu
+++ b/config/Julia/Main.sublime-menu
@@ -20,7 +20,7 @@
                         "linux": "utf8",
                         "osx": "utf8"
                         },
-                    "cmd": {"linux": ["julia-release-basic"],
+                    "cmd": {"linux": ["julia-basic"],
                             "osx": ["julia-release-basic"],
                             "windows": ["julia-basic.bat"]},
                     "cwd": "$file_path",


### PR DESCRIPTION
The prompt symbol is missing in my computer (Ubuntu 13.10). Does that happen on you?
